### PR TITLE
Added EarlyWhiteBalance, CorrectSaturated and ClipMode Options, and o…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,13 @@ New features:
 - LFBuild2DLPF, LFBuild4DLPF for frequency-domain lowpass filters, optionally anisotropic
 - Smarter search for of white image and calibration databases decoding and rectifying; More informative error messages when locating white databases / files
 
+Decoding improvements:
+- New decode options WeightedDemosaic, WeightedInterp for improved demosaicing and interpolations (reduce ghosting artifacts on external views).
+- Improved colours and exposure with decode options NormaliseWIColours, NormaliseWIExposure and corrected use of metadata for Lytro Illum (behaviour of previous versions is still available with decode option ColourCompatibility).
+- New decode options CorrectSaturated and ClipMode for the recovery of saturated colours in the highlights.
+- New decode option EarlyWhiteBalance to perform white balance on the RAW lenslet image directly (reduce some colour artifacts).
+
+
 ---v0.5.1----------------------------------------------------------------------
 Minor bug fixes and improvements
 

--- a/LFColourCorrect.m
+++ b/LFColourCorrect.m
@@ -31,7 +31,7 @@
 
 % Copyright (c) 2013-2020 Donald G. Dansereau
 
-function LF = LFColourCorrect(LF, ColMatrix, ColBalance, Gamma)
+function LF = LFColourCorrect(LF, ColMatrix, ColBalance, SaturationLevel, doClip, Gamma)
 
 LFSize = size(LF);
 
@@ -45,11 +45,12 @@ LF = LF * ColMatrix;
 % Unflatten result
 LF = reshape(LF, [LFSize(1:NDims-1),3]);
 
-% Saturating eliminates some issues with clipped pixels, but is aggressive and loses information
-% todo[optimization]: find a better approach to dealing with saturated pixels
-SaturationLevel = ColBalance*ColMatrix;
-SaturationLevel = min(SaturationLevel);
-LF = min(SaturationLevel,max(0,LF)) ./ SaturationLevel; 
+if(doClip)
+    % Saturating eliminates some issues with clipped pixels, but is aggressive and loses information
+    LF = min(SaturationLevel,max(0,LF)) ./ SaturationLevel; 
+else
+    LF = LF ./ SaturationLevel;
+end
 
 % Apply gamma
 LF = LF .^ Gamma;

--- a/LFLytroDecodeImage.m
+++ b/LFLytroDecodeImage.m
@@ -72,7 +72,6 @@ DecodeOptions = LFDefaultField( 'DecodeOptions', 'WhiteImageDatabasePath', fullf
 % Compatibility: for loading extracted raw / json files
 DecodeOptions = LFDefaultField( 'DecodeOptions', 'MetadataFnamePattern', '_metadata.json' );
 DecodeOptions = LFDefaultField( 'DecodeOptions', 'SerialdataFnamePattern', '_private_metadata.json' );
-DecodeOptions = LFDefaultField( 'DecodeOptions', 'ColourCompatibility', true );
 
 %---
 LF = [];


### PR DESCRIPTION
…ther corrections

-CorrectSaturated: correct colours of saturated highlights so that they appear white after the white balance (recovers some detail in the highlights).
To test the effect, compare the result using options (OptionalTasks={'ColourCorrect'}, ColourCompatibility=false) with that of (OptionalTasks={'ColourCorrect'}, ColourCompatibility=false, CorrectSaturated=true).

-ClipMode is either 'hard' (previous behaviour), 'soft' (new soft saturation function) or 'none' (no clipping).
The default is 'soft' when CorrectSaturated is true, and 'hard' otherwise (highlights retrieved with CorrectSaturated are better preserved with soft clipping).
The mode 'none' divides the output LF by the maximul value MaxLum to prevent any clipping in the integer conversion. MaxLum is saved in metadata. To recover the correct brightness, the output must be multiplied by MaxLum (after conversion to float data).

-EarlyWhiteBalance (default=false) Performs the white balance before the call to LFColourCorrect. It applies white balance even if the 'ColourCorrect' optional task is not specified.
To test the effect, compare the result using options (OptionalTasks={'ColourCorrect'}, ColourCompatibility=false) with that of (OptionalTasks={'ColourCorrect'}, ColourCompatibility=false, EarlyWhiteBalance=true).
The difference of EarlyWhiteBalance is subtle, but it should give slightly reduced demosaicing artifacts, and better preserved colours.

-Other changes/corrections:
  -Disabled the change of saturationLevel in LFColourCorrect when the ColourCompatibility option is off. It was causing too bright images and unexpected change of brightness when switching the new EarlyWhiteBalance option on or off.
So previous tests with corrections of colours and exposure should be run again for correct exposure.
  -Always desactivate NormaliseWIExposure and NormaliseWIColours when ColourCompatibility is true (WI normalisation does not make sense in this case).
But their default is now set to true otherwise, so setting ColourCompatibility to false gives the intended colours without adjusting other options.