### PR TITLE
Added Resampling methods 'barycentric' and 'none'

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,8 @@ Decoding improvements:
 - Improved colours and exposure with decode options NormaliseWIColours, NormaliseWIExposure and corrected use of metadata for Lytro Illum (behaviour of previous versions is still available with decode option ColourCompatibility).
 - New decode options CorrectSaturated and ClipMode for the recovery of saturated colours in the highlights.
 - New decode option EarlyWhiteBalance to perform white balance on the RAW lenslet image directly (reduce some colour artifacts).
+- New ResampMethod option 'barycentric' from the ICCV2013 paper of Cho et al, "Modeling the calibration pipeline of the Lytro camera for high quality light-field image reconstruction".
+- New ResampMethod option 'none' from ICCP2020 paper of Le Pendu and Smolic, "High Resolution Light Field Recovery with Fourier Disparity Layer Completion, Demosaicing, and Super-Resolution".
 
 Misc improvements:
 - LFWriteESLF: smarter jpeg file writing; reduces to 8-bit and strips weight channel as needed

--- a/LFLytroDecodeImage.m
+++ b/LFLytroDecodeImage.m
@@ -169,6 +169,10 @@ switch( WhiteImageMetadata.camera.model )
             DecodeOptions.ExposureBias = LFMetadata.image.modulationExposureBias + 1;
         end
         
+        if(isfield(DecodeOptions,'ResampMethod') && DecodeOptions.ResampMethod)
+            DecodeOptions = LFDefaultField( 'DecodeOptions', 'NumViewsDiameter', 17 );
+            DecodeOptions = LFDefaultField( 'DecodeOptions', 'LensletBorderSkip', 1.5 );
+        end
         
         BitPacking = '12bit';
         
@@ -190,6 +194,11 @@ switch( WhiteImageMetadata.camera.model )
             DecodeOptions.ExposureBias = LFMetadata.image.modulationExposureBias;
         end
         
+        if(isfield(DecodeOptions,'ResampMethod') && strcmp(DecodeOptions.ResampMethod,'none'))
+            DecodeOptions = LFDefaultField( 'DecodeOptions', 'NumViewsDiameter', 25 );
+            DecodeOptions = LFDefaultField( 'DecodeOptions', 'LensletBorderSkip', 1.5 );
+        end
+        
         DecodeOptions.Gamma = 1;
         DecodeOptions.SensorNormalizeRBGains =   [WhiteImageMetadata.devices.sensor.normalizedResponses.gr/WhiteImageMetadata.devices.sensor.normalizedResponses.r, ...
                                                   WhiteImageMetadata.devices.sensor.normalizedResponses.gr/WhiteImageMetadata.devices.sensor.normalizedResponses.b];
@@ -204,6 +213,6 @@ WhiteImage = LFReadRaw( WhiteRawFname, BitPacking );
 %---Decode---
 fprintf('Decoding lenslet image :');
 [LF, LFWeight, DecodeOptions] = LFDecodeLensletImageDirect( LensletImage, WhiteImage, LensletGridModel, DecodeOptions );
-LF(:,:,:,:,4) = LFWeight;
+LF(:,:,:,:,end+1:end+DecodeOptions.NWeightChans) = LFWeight;
 DecodeOptions.LFSize = size(LF);
 

--- a/LFUtilDecodeLytroFolder.m
+++ b/LFUtilDecodeLytroFolder.m
@@ -93,7 +93,10 @@
 %          .WhiteImageDatabaseFname : Filename of the white image database, default WhiteImageDatabase.json
 %                          .DoDehex : Controls whether hexagonal sampling is converted to rectangular, default true
 %                       .DoSquareST : Controls whether s,t dimensions are resampled to square pixels, default true
-%                     .ResampMethod : 'fast'(default) or 'triangulation'
+%                     .ResampMethod : 'fast'(default)
+%                                     'triangulation'
+%                                     'barycentric': slower but generates higher resolution images by a factor 3*sqrt(3)/2.
+%                                     'none': No interpolation -> Generates many incomplete views with a weight map per RGB component (zero weight indicate missing pixel).
 %                      .LevelLimits : a two-element vector defining the black and white levels
 %                        .Precision : 'single'(default) or 'double'
 %                 .WeightedDemosaic : Do White Image guided demosaicing, default=false.
@@ -192,6 +195,10 @@ if( DecodeOptions.ColourCompatibility )
     DecodeOptions.NormaliseWIExposure = false;
 end
 
+if(isfield(DecodeOptions,'ResampMethod') && strcmp(DecodeOptions.ResampMethod,'none') && ~strcmp(FileOptions.OutputFormat,'mat'))
+    warning('Only ''mat'' file OutputFormat is available with ResampMethod option set to ''none'' -> Using ''mat'' output format.');
+    FileOptions.OutputFormat = 'mat';
+end
 
 RectOptions = LFDefaultField('RectOptions', 'CalibrationDatabaseFname', 'CalibrationDatabase.json');
 RectOptions = LFDefaultField('RectOptions', 'CalibrationDatabasePath', fileparts(DecodeOptions.WhiteImageDatabasePath));
@@ -449,13 +456,19 @@ function LF = ColourCorrect( LF, LFMetadata, DecodeOptions )
 fprintf('Applying colour correction... ');
 
 %---Weight channel is not used by colour correction, so strip it out---
-LFWeight = LF(:,:,:,:,4);
-LF = LF(:,:,:,:,1:3);
+LFWeight = LF(:,:,:,:,DecodeOptions.NColChans+1:DecodeOptions.NColChans+DecodeOptions.NWeightChans);
+LF = LF(:,:,:,:,1:DecodeOptions.NColChans);
 
 if( DecodeOptions.EarlyWhiteBalance )
     ColBalance = [1 1 1]; %White Balance is already performed
 else
     ColBalance = DecodeOptions.ColourBalance;
+end
+
+if(strcmp(DecodeOptions.ResampMethod,'none'))
+    ColMatrix = eye(3); %Skip colour transform to avoid mixing RGB data since at most one component per pixel is reliable.
+else
+    ColMatrix = DecodeOptions.ColourMatrix;
 end
 
 if( DecodeOptions.ColourCompatibility )
@@ -468,10 +481,10 @@ end
 doClip = ~strcmp(DecodeOptions.ClipMode,'none');
 
 %---Apply the color conversion and saturate---
-LF = LFColourCorrect( LF, DecodeOptions.ColourMatrix, ColBalance, DecodeOptions.Gamma, SaturationLevel, doClip );
+LF = LFColourCorrect( LF, ColMatrix, ColBalance, DecodeOptions.Gamma, SaturationLevel, doClip );
 
 %---Put the weight channel back---
-LF(:,:,:,:,4) = LFWeight;
+LF(:,:,:,:,DecodeOptions.NColChans+1:DecodeOptions.NColChans+DecodeOptions.NWeightChans) = LFWeight;
 
 end
 

--- a/SupportFunctions/LFDecodeLensletImageDirect.m
+++ b/SupportFunctions/LFDecodeLensletImageDirect.m
@@ -30,7 +30,10 @@
 % LFBuildLensletGridModel -- see that function for more on the required structure.
 %
 % Optional Input DecodeOptions is a structure containing:
-%          [Optional] ResampMethod : 'fast'(default) or 'triangulation', the latter is slower
+%          [Optional] ResampMethod : 'fast'(default)
+%                                    'triangulation' slower.
+%                                    'barycentric': slow but generates higher resolution images by a factor 3*sqrt(3)/2.
+%                                    'none': No interpolation -> Generates many incomplete views with a weight map per RGB component (zero weight indicate missing pixel).
 %          [Optional]   Precision : 'single'(default) or 'double'
 %          [Optional] LevelLimits : a two-element vector defining the black and white levels
 %          [Optional] WeightedDemosaic : Do White Image guided demosaicing (default=false).
@@ -70,7 +73,7 @@ function [LF, LFWeight, DecodeOptions, DebayerLensletImage] = ...
 %---Defaults---
  % LevelLimits defaults are a failsafe, should be passed in / come from the white image metadata
 DecodeOptions = LFDefaultField( 'DecodeOptions', 'LevelLimits', [min(WhiteImage(:)), max(WhiteImage(:))] );
-DecodeOptions = LFDefaultField( 'DecodeOptions', 'ResampMethod', 'fast' ); %'fast', 'triangulation'
+DecodeOptions = LFDefaultField( 'DecodeOptions', 'ResampMethod', 'fast' ); %'fast', 'triangulation', 'barycentric', 'none'
 DecodeOptions = LFDefaultField( 'DecodeOptions', 'Precision', 'single' );
 DecodeOptions = LFDefaultField( 'DecodeOptions', 'DoDehex', true );
 DecodeOptions = LFDefaultField( 'DecodeOptions', 'DoSquareST', true );
@@ -86,8 +89,11 @@ else
     DefaultClipMode='hard';
 end
 DecodeOptions = LFDefaultField( 'DecodeOptions', 'ClipMode', DefaultClipMode );% 'none', 'soft', 'hard'
+if(strcmp(DecodeOptions.ResampMethod,'none') || strcmp(DecodeOptions.ResampMethod,'none'))
+    %Weigthed interpolation not compatible with the ResampMode modes 'barycentric' and 'none'
+    DecodeOptions.WeightedInterp=false;
+end
 
-    
 %---Rescale image values, remove black level---
 DecodeOptions.LevelLimits = cast(DecodeOptions.LevelLimits, DecodeOptions.Precision);
 BlackLevel = DecodeOptions.LevelLimits(1);
@@ -229,7 +235,11 @@ end
 DecodeOptions.NColChans = 3;
 
 if( nargout >= 2 )
-    DecodeOptions.NWeightChans = 1;
+    if(strcmp(DecodeOptions.ResampMethod,'none'))
+        DecodeOptions.NWeightChans = 3;
+    else
+        DecodeOptions.NWeightChans = 1;
+    end
 else
     DecodeOptions.NWeightChans = 0;
 end
@@ -267,144 +277,267 @@ DecodeOptions.OutputScale(3:4) = [1,2/sqrt(3)];  % hex sampling
 RTrans = eye(3);
 RTrans(end,1:2) = XformTrans;
 
+
+if(~strcmp(DecodeOptions.ResampMethod,'barycentric') && ~strcmp(DecodeOptions.ResampMethod,'none'))
 % The following rotation can rotate parts of the lenslet image out of frame.
 % todo[optimization]: attempt to keep these regions, offer greater user-control of what's kept
-FixAll = RRot*RScale*RTrans;
-LensletImage(:,:,4) = WhiteImage;
-clear WhiteImage
-LF = SliceXYImage( FixAll, NewLensletGridModel, LensletImage, DecodeOptions, Weights, Belonging, MLCenters);
-clear LensletImage
+    FixAll = RRot*RScale*RTrans;
+    LensletImage(:,:,4) = WhiteImage;
+    clear WhiteImage
+    LF = SliceXYImage( FixAll, NewLensletGridModel, LensletImage, DecodeOptions, Weights, Belonging, MLCenters);
+    clear LensletImage
 
-%---Correct for hex grid and resize to square u,v pixels---
-LFSize = size(LF);
-HexAspect = 2/sqrt(3);
-switch( DecodeOptions.ResampMethod )
-    case 'fast'
-        fprintf('\nResampling (1D approximation) to square u,v pixels');
-        NewUVec = 0:1/HexAspect:(size(LF,4)+1);  % overshoot then trim
-        NewUVec = NewUVec(1:ceil(LFSize(4)*HexAspect));
-        OrigUSize = size(LF,4);
-        LFSize(4) = length(NewUVec);
-        %---Allocate dest and copy orig LF into it (memory saving vs. keeping both separately)---
-        LF2 = zeros(LFSize, DecodeOptions.Precision);
-        LF2(:,:,:,1:OrigUSize,:) = LF;
-        LF = LF2;
-        clear LF2
-        
-        if( DecodeOptions.DoDehex )
-            ShiftUVec = -0.5+NewUVec;
-            fprintf(' and removing hex sampling...');
-        else
-            ShiftUVec = NewUVec;
-            fprintf('...');
+    %---Correct for hex grid and resize to square u,v pixels---
+    LFSize = size(LF);
+    HexAspect = 2/sqrt(3);
+    switch( DecodeOptions.ResampMethod )
+        case 'fast'
+            fprintf('\nResampling (1D approximation) to square u,v pixels');
+            NewUVec = 0:1/HexAspect:(size(LF,4)+1);  % overshoot then trim
+            NewUVec = NewUVec(1:ceil(LFSize(4)*HexAspect));
+            OrigUSize = size(LF,4);
+            LFSize(4) = length(NewUVec);
+            %---Allocate dest and copy orig LF into it (memory saving vs. keeping both separately)---
+            LF2 = zeros(LFSize, DecodeOptions.Precision);
+            LF2(:,:,:,1:OrigUSize,:) = LF;
+            LF = LF2;
+            clear LF2
+
+            if( DecodeOptions.DoDehex )
+                ShiftUVec = -0.5+NewUVec;
+                fprintf(' and removing hex sampling...');
+            else
+                ShiftUVec = NewUVec;
+                fprintf('...');
+            end
+            for( ColChan = 1:size(LF,5) )
+                CurUVec = ShiftUVec;
+                for( RowIter = 1:2 )
+                    RowIdx = mod(NewLensletGridModel.FirstPosShiftRow + RowIter, 2) + 1;
+                    ShiftRows = squeeze(LF(:,:,RowIdx:2:end,1:OrigUSize, ColChan));
+                    SliceSize = size(ShiftRows);
+                    SliceSize(4) = length(NewUVec);
+                    ShiftRows = reshape(ShiftRows, [size(ShiftRows,1)*size(ShiftRows,2)*size(ShiftRows,3), size(ShiftRows,4)]);
+                    ShiftRows = interp1( (0:size(ShiftRows,2)-1)', ShiftRows', CurUVec' )';
+                    ShiftRows(isnan(ShiftRows)) = 0;
+                    LF(:,:,RowIdx:2:end,:,ColChan) = reshape(ShiftRows,SliceSize);
+                    CurUVec = NewUVec;
+                end
+            end
+            clear ShiftRows
+            DecodeOptions.OutputScale(3) = DecodeOptions.OutputScale(3) * HexAspect;
+
+        case 'triangulation'
+            fprintf('\nResampling (triangulation) to square u,v pixels');
+            OldVVec = (0:size(LF,3)-1);
+            OldUVec = (0:size(LF,4)-1) * HexAspect;
+
+            NewUVec = (0:ceil(LFSize(4)*HexAspect)-1);
+            NewVVec = (0:LFSize(3)-1);
+            LFSize(4) = length(NewUVec);
+            LF2 = zeros(LFSize, DecodeOptions.Precision);
+
+            [Oldvv,Olduu] = ndgrid(OldVVec,OldUVec);
+            [Newvv,Newuu] = ndgrid(NewVVec,NewUVec);
+            if( DecodeOptions.DoDehex )
+                fprintf(' and removing hex sampling...');
+                FirstShiftRow = NewLensletGridModel.FirstPosShiftRow;
+                Olduu(FirstShiftRow:2:end,:) = Olduu(FirstShiftRow:2:end,:) + HexAspect/2;
+            else
+                fprintf('...');
+            end
+
+            DT = delaunayTriangulation( Olduu(:), Oldvv(:) );  % use DelaunayTri in older Matlab versions
+            [ti,bc] = pointLocation(DT, Newuu(:), Newvv(:));
+            ti(isnan(ti)) = 1;
+
+            for( ColChan = 1:size(LF,5) )
+                fprintf('.');
+                for( tidx= 1:LFSize(1) )
+                    for( sidx= 1:LFSize(2) )
+                        CurUVSlice = squeeze(LF(tidx,sidx,:,:,ColChan));
+                        triVals = CurUVSlice(DT(ti,:));
+                        CurUVSlice = dot(bc',triVals')';
+                        CurUVSlice = reshape(CurUVSlice, [length(NewVVec),length(NewUVec)]);
+
+                        CurUVSlice(isnan(CurUVSlice)) = 0;
+                        LF2(tidx,sidx, :,:, ColChan) = CurUVSlice;
+                    end
+                end
+            end
+            LF = LF2;
+            clear LF2
+            DecodeOptions.OutputScale(3) = DecodeOptions.OutputScale(3) * HexAspect;
+
+        otherwise
+            fprintf('\nNo valid dehex / resampling selected\n');
+    end
+
+    %---Resize to square s,t pixels---
+    % Assumes only a very slight resampling is required, resulting in an identically-sized output light field
+    if( DecodeOptions.DoSquareST )
+        fprintf('\nResizing to square s,t pixels using 1D linear interp...');
+
+        ResizeScale = DecodeOptions.OutputScale(1)/DecodeOptions.OutputScale(2);
+        ResizeDim1 = 1;
+        ResizeDim2 = 2;
+        if( ResizeScale < 1 )
+            ResizeScale = 1/ResizeScale;
+            ResizeDim1 = 2;
+            ResizeDim2 = 1;
         end
-        for( ColChan = 1:size(LF,5) )
-            CurUVec = ShiftUVec;
-            for( RowIter = 1:2 )
-                RowIdx = mod(NewLensletGridModel.FirstPosShiftRow + RowIter, 2) + 1;
-                ShiftRows = squeeze(LF(:,:,RowIdx:2:end,1:OrigUSize, ColChan));
-                SliceSize = size(ShiftRows);
-                SliceSize(4) = length(NewUVec);
-                ShiftRows = reshape(ShiftRows, [size(ShiftRows,1)*size(ShiftRows,2)*size(ShiftRows,3), size(ShiftRows,4)]);
-                ShiftRows = interp1( (0:size(ShiftRows,2)-1)', ShiftRows', CurUVec' )';
-                ShiftRows(isnan(ShiftRows)) = 0;
-                LF(:,:,RowIdx:2:end,:,ColChan) = reshape(ShiftRows,SliceSize);
-                CurUVec = NewUVec;
+
+        OrigSize = size(LF, ResizeDim1);
+        OrigVec = floor((-(OrigSize-1)/2):((OrigSize-1)/2));
+        NewVec = OrigVec ./ ResizeScale;
+
+        OrigDims = [1:ResizeDim1-1, ResizeDim1+1:5];
+
+        UBlkSize = 32;
+        USize = size(LF,4);
+        LF = permute(LF,[ResizeDim1, OrigDims]);
+        for( UStart = 1:UBlkSize:USize )
+            UStop = UStart + UBlkSize - 1;
+            UStop = min(UStop, USize);
+            LF(:,:,:,UStart:UStop,:) = interp1(OrigVec, LF(:,:,:,UStart:UStop,:), NewVec);
+            fprintf('.');
+        end
+        LF = ipermute(LF,[ResizeDim1, OrigDims]);
+        LF(isnan(LF)) = 0;
+
+        DecodeOptions.OutputScale(ResizeDim2) = DecodeOptions.OutputScale(ResizeDim2) * ResizeScale;
+    end
+
+else %Alternative Resampling modes 'none' and 'barycentric
+    
+    fprintf('\nInterpolating subaperture images from raw data...');
+    
+    USize = LensletGridModel.UMax;
+    VSize = LensletGridModel.VMax;
+    HOffset = LensletGridModel.HOffset;
+    VOffset = LensletGridModel.VOffset;
+    HSpacing = LensletGridModel.HSpacing;
+    VSpacing = LensletGridModel.VSpacing;
+    HexShiftStart = LensletGridModel.FirstPosShiftRow;
+    
+    [uu, vv] = meshgrid( 0:USize-1 , 0:VSize-1 );
+    centerX = HOffset + HSpacing * uu;
+    centerX(HexShiftStart:2:end,:) = centerX(HexShiftStart:2:end,:) + HSpacing/2;
+    centerY = VOffset + VSpacing * vv;
+
+    RotatedCenters = [centerX(:),centerY(:)] * RRot(1:2,1:2)';
+    centerX(:) = RotatedCenters(:,1);
+    centerY(:) = RotatedCenters(:,2);
+    
+    if(strcmp(DecodeOptions.ResampMethod,'barycentric'))
+        STVec = linspace(-HSpacing/2,HSpacing/2, NewLensletGridModel.HSpacing+1);%view positions cover the full lenslet diameter (=hspacing)
+        VSizeNew = floor(VSize*3*sqrt(3)/2);
+        USizeNew = USize*3;
+        LF = ones(length(STVec), length(STVec), VSizeNew, USizeNew, DecodeOptions.NColChans + DecodeOptions.NWeightChans, DecodeOptions.Precision);
+        
+        first = true;
+        for row = 1:length(STVec)
+            for col = 1:length(STVec)
+                vecFix = RRot * [STVec(col); STVec(row); 1];
+                colOffset = vecFix(1)/vecFix(3);
+                rowOffset = vecFix(2)/vecFix(3);
+                hex = zeros(2*VSize,2*USize,DecodeOptions.NColChans+DecodeOptions.NWeightChans);
+                img = zeros(VSizeNew,USizeNew,DecodeOptions.NColChans+DecodeOptions.NWeightChans);
+                for ch = 1:DecodeOptions.NColChans+DecodeOptions.NWeightChans
+                    if(ch<=DecodeOptions.NColChans)
+                        InterpSlice = interpn(squeeze(LensletImage(:,:,ch)), centerY+rowOffset, centerX+colOffset, 'cubic');
+                    else
+                        InterpSlice = interpn(squeeze(WhiteImage), centerY+rowOffset, centerX+colOffset, 'cubic');
+                    end
+                    hex(1:4:end,3-HexShiftStart:2:end,ch) = InterpSlice(1:2:end,:);
+                    hex(3:4:end,HexShiftStart:2:end,ch) = InterpSlice(2:2:end,:);
+                    if(first)
+                        [img(:,:,ch), InterpData] = baryCentric(hex(:,:,ch),VSize/2,USize, HexShiftStart);
+                        first = false;
+                    else
+                       img(:,:,ch) = baryCentric(hex(:,:,ch),VSize/2,USize, HexShiftStart, InterpData);
+                    end
+                end
+                LF(row, col,:,:,1:DecodeOptions.NColChans+DecodeOptions.NWeightChans) = cast(img,DecodeOptions.Precision);
             end
         end
-        clear ShiftRows
-        DecodeOptions.OutputScale(3) = DecodeOptions.OutputScale(3) * HexAspect;
         
-    case 'triangulation'
-        fprintf('\nResampling (triangulation) to square u,v pixels');
-        OldVVec = (0:size(LF,3)-1);
-        OldUVec = (0:size(LF,4)-1) * HexAspect;
+    else  % ResampMode 'none' -> only nearest interpolations with 
         
-        NewUVec = (0:ceil(LFSize(4)*HexAspect)-1);
-        NewVVec = (0:LFSize(3)-1);
-        LFSize(4) = length(NewUVec);
-        LF2 = zeros(LFSize, DecodeOptions.Precision);
+        G1Xparity = mod(G1stX,2); G1Yparity = mod(G1stY,2);
+        G2Xparity = mod(G2stX,2); G2Yparity = mod(G2stY,2);
+        RXparity  = mod(RstX,2);  RYparity  = mod(RstY,2);
+        BXparity  = mod(BstX,2);  BYparity  = mod(BstY,2);
         
-        [Oldvv,Olduu] = ndgrid(OldVVec,OldUVec);
-        [Newvv,Newuu] = ndgrid(NewVVec,NewUVec);
-        if( DecodeOptions.DoDehex )
-            fprintf(' and removing hex sampling...');
-            FirstShiftRow = NewLensletGridModel.FirstPosShiftRow;
-            Olduu(FirstShiftRow:2:end,:) = Olduu(FirstShiftRow:2:end,:) + HexAspect/2;
-        else
-            fprintf('...');
-        end
-        
-        DT = delaunayTriangulation( Olduu(:), Oldvv(:) );  % use DelaunayTri in older Matlab versions
-        [ti,bc] = pointLocation(DT, Newuu(:), Newvv(:));
-        ti(isnan(ti)) = 1;
-        
-        for( ColChan = 1:size(LF,5) )
-            fprintf('.');
-            for( tidx= 1:LFSize(1) )
-                for( sidx= 1:LFSize(2) )
-                    CurUVSlice = squeeze(LF(tidx,sidx,:,:,ColChan));
-                    triVals = CurUVSlice(DT(ti,:));
-                    CurUVSlice = dot(bc',triVals')';
-                    CurUVSlice = reshape(CurUVSlice, [length(NewVVec),length(NewUVec)]);
+        radius = (HSpacing-1)/2 - DecodeOptions.LensletBorderSkip;
+        STVec = linspace(-radius, radius, DecodeOptions.NumViewsDiameter);%oversample in ST dimension for better accuracy of nearest interpolation.
+        [S,T]=meshgrid(STVec,STVec);
+        STkeep = (S.^2+T.^2)<=radius.^2;
+        S = S(STkeep);
+        T = T(STkeep);
+        STVec = RRot * [S(:)'; T(:)'; ones(1,numel(S))];
+        S = STVec(1,:);
+        T = STVec(2,:);
+        nViews = numel(S);
+        DecodeOptions.Sampling.ST = [S(:), T(:)];%[S(:), T(:)*2/sqrt(3)];
+        DecodeOptions.Sampling.HexShiftStart = HexShiftStart;
+        DecodeOptions.Sampling.SubPixAccuracy=2*radius/(DecodeOptions.NumViewsDiameter-1);
+
+        LF = zeros(nViews, 1, VSize, USize, DecodeOptions.NColChans + DecodeOptions.NWeightChans, DecodeOptions.Precision);
+
+        %Only assign a sensor pixel value to its nearest pixel in the light field.
+        nearPxThreshold = DecodeOptions.Sampling.SubPixAccuracy/sqrt(2);
+        buffer_IdOut = zeros(size(LensletImage,1),size(LensletImage,2));
+        buffer_Dist = inf(size(LensletImage,1),size(LensletImage,2));
+        numPixPerView = USize*VSize;
+        DecodeOptions.Sampling.ViewWeights = ones(numel(S),1);
+        for viewId = 1:numel(S)
+            %Find the colour view and mask (unknown->0 / known->weight from the white image).
+            for xId=1:USize
+                for yId=1:VSize
+                    vxyId = (viewId-1)*numPixPerView + (xId-1)*VSize + yId;
+                    Xreq = centerX(yId,xId) + S(viewId);
+                    Yreq = centerY(yId,xId) + T(viewId);
+                    Xnear = min(max(round(Xreq),1),size(LensletImage,2));
+                    Ynear = min(max(round(Yreq),1),size(LensletImage,1));
+                    dist2 = (Xnear-Xreq).^2+(Ynear-Yreq).^2;
+                    LF(viewId,1,yId,xId,1:DecodeOptions.NColChans) = LensletImage(Ynear,Xnear,:);
                     
-                    CurUVSlice(isnan(CurUVSlice)) = 0;
-                    LF2(tidx,sidx, :,:, ColChan) = CurUVSlice;
+                    if( DecodeOptions.NWeightChans==3 && dist2 < buffer_Dist(Ynear,Xnear) )
+                        isNeighbour = abs(Xreq-Xnear) < nearPxThreshold  & abs(Yreq-Ynear) < nearPxThreshold;
+                        weight = WhiteImage(Ynear,Xnear);
+                        LF(viewId,1,yId,xId,DecodeOptions.NColChans+1) = weight * ( isNeighbour & mod(Xnear,2) == RXparity & mod(Ynear,2) == RYparity );
+                        LF(viewId,1,yId,xId,DecodeOptions.NColChans+2) = weight * ( isNeighbour & (mod(Xnear,2) == G1Xparity & mod(Ynear,2) == G1Yparity | mod(Xnear,2) == G2Xparity & mod(Ynear,2) == G2Yparity) );
+                        LF(viewId,1,yId,xId,DecodeOptions.NColChans+3) = weight * ( isNeighbour & mod(Xnear,2) == BXparity & mod(Ynear,2) == BYparity );
+                        
+                        %Remove previous closest pixel (set its mask value to zero)
+                        vxyIdPrev = buffer_IdOut(Ynear,Xnear);
+                        if(vxyIdPrev>0)
+                            viewIdPrev = 1+floor((vxyIdPrev-1)/numPixPerView);
+                            xIdPrev = 1 + floor((vxyIdPrev-(viewIdPrev-1)*numPixPerView-1)/VSize);
+                            yIdPrev = vxyIdPrev - (viewIdPrev-1)*numPixPerView - (xIdPrev-1)*VSize;
+                            LF(viewIdPrev,1,yIdPrev,xIdPrev,1+DecodeOptions.NColChans:DecodeOptions.NColChans+3) = 0;
+                        end
+                        %Update index and distance buffers with new closest pixel info.
+                        buffer_IdOut(Ynear,Xnear) = vxyId;
+                        buffer_Dist(Ynear,Xnear) = dist2;
+                    end
                 end
             end
         end
-        LF = LF2;
-        clear LF2
-        DecodeOptions.OutputScale(3) = DecodeOptions.OutputScale(3) * HexAspect;
-        
-    otherwise
-        fprintf('\nNo valid dehex / resampling selected\n');
-end
-
-%---Resize to square s,t pixels---
-% Assumes only a very slight resampling is required, resulting in an identically-sized output light field
-if( DecodeOptions.DoSquareST )
-    fprintf('\nResizing to square s,t pixels using 1D linear interp...');
-    
-    ResizeScale = DecodeOptions.OutputScale(1)/DecodeOptions.OutputScale(2);
-    ResizeDim1 = 1;
-    ResizeDim2 = 2;
-    if( ResizeScale < 1 )
-        ResizeScale = 1/ResizeScale;
-        ResizeDim1 = 2;
-        ResizeDim2 = 1;
     end
-    
-    OrigSize = size(LF, ResizeDim1);
-    OrigVec = floor((-(OrigSize-1)/2):((OrigSize-1)/2));
-    NewVec = OrigVec ./ ResizeScale;
-    
-    OrigDims = [1:ResizeDim1-1, ResizeDim1+1:5];
-    
-    UBlkSize = 32;
-    USize = size(LF,4);
-    LF = permute(LF,[ResizeDim1, OrigDims]);
-    for( UStart = 1:UBlkSize:USize )
-        UStop = UStart + UBlkSize - 1;
-        UStop = min(UStop, USize);
-        LF(:,:,:,UStart:UStop,:) = interp1(OrigVec, LF(:,:,:,UStart:UStop,:), NewVec);
-        fprintf('.');
-    end
-    LF = ipermute(LF,[ResizeDim1, OrigDims]);
-    LF(isnan(LF)) = 0;
-    
-    DecodeOptions.OutputScale(ResizeDim2) = DecodeOptions.OutputScale(ResizeDim2) * ResizeScale;
 end
-
 
 %---Trim s,t---
-LF = LF(2:end-1,2:end-1, :,:, :);
+if(~strcmp(DecodeOptions.ResampMethod,'none'))
+    LF = LF(2:end-1,2:end-1, :,:, :);
+end
 
 %---Slice out LFWeight if it was requested---
 if( nargout >= 2 )
-    LFWeight = LF(:,:,:,:,end);
+    LFWeight = LF(:,:,:,:,DecodeOptions.NColChans+1:end);
     LFWeight = LFWeight./max(LFWeight(:));
-    LF = LF(:,:,:,:,1:end-1);
+    LF = LF(:,:,:,:,1:DecodeOptions.NColChans);
 end
 
 end

--- a/SupportFunctions/baryCentric.m
+++ b/SupportFunctions/baryCentric.m
@@ -1,0 +1,171 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% original code from KAIST toolbox written by Donghyeon Cho.
+%
+% modified by Mikael Le Pendu : 19 Aug.2016
+%  - adapted inputs/outputs for the LFtoolbox pipeline.
+%
+% Name   : baryCentric
+% Input  : img           - input image
+%          height        - image height
+%          width         - image width
+%          HexShiftStart - 1 => first column (and all odd columns) of
+%          lenslets are shifted horizontally by the lenslet radius.
+%                          2=> second column (and all even columns) of
+%          lenslets are shifted horizontally by the lenslet radius.
+%          InterpData    - (optional) pre-computed Delaunay triangulation
+%          data. If not given, it will be computed and returned in output.
+%
+% Output : result     - images
+%          InterpData - Data from Delaunay triangulation (to avoid
+%          recomputing Delaunay triangulation for next calls).
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function [result,InterpData] = baryCentric(img,height,width,HexShiftStart,InterpData)
+    
+    % image coordinate
+    result = zeros(floor(height*3*sqrt(3)),width*3);
+    [indexX, indexY] = meshgrid(1:width*3,1:floor(height*3*sqrt(3)));
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    if(nargin<5 || isempty(InterpData))
+    
+        if(nargin<4 || isempty(HexShiftStart)), HexShiftStart=2;end
+        
+        % hexagonal grid coordinate
+        hex_grid1.X = (1+(2-HexShiftStart)*1.5:3:3*width);
+        hex_grid1.Y = (1:3*sqrt(3):3*sqrt(3)*height);
+        hex_grid2.X = (1+(HexShiftStart-1)*1.5:3:3*width);
+        hex_grid2.Y = (sqrt(3)*3/2+1:3*sqrt(3):3*sqrt(3)*height);
+
+        [X1, Y1] = meshgrid(hex_grid1.X,hex_grid1.Y);
+        [X2, Y2] = meshgrid(hex_grid2.X,hex_grid2.Y);
+        X = [X1(:) ; X2(:)];
+        Y = [Y1(:) ; Y2(:)];
+        DT = DelaunayTri(X,Y);
+
+        % find nearest pixel in triangle
+        CORESP = nearestNeighbor(DT, indexX(:),indexY(:));
+
+        hx_nearest = round((X(CORESP)-1)*2/3)+1;
+        hy_nearest = round((Y(CORESP)-1)*2/(3*sqrt(3)/2))+1;
+
+        hx0 = ((indexX(:)-1)*2/3)+1;
+        hy0 = ((indexY(:)-1)*2/(3*sqrt(3)/2))+1;
+
+        % 6 neighbor pixels 
+        hnx = [hx_nearest-1 hx_nearest+1 hx_nearest+2 hx_nearest+1 hx_nearest-1 hx_nearest-2];
+        hny = [hy_nearest-2 hy_nearest-2 hy_nearest hy_nearest+2 hy_nearest+2 hy_nearest];
+
+        % find second nearest neighbor
+        dis = sqrt( (hnx-repmat(hx0,[1 6])).^2 + (hny-repmat(hy0,[1 6])).^2);
+        [m,  index]= min(dis,[],2);
+
+        tmp_index = index' + 6*[0:length(index)-1];
+        hnx1 = hnx';
+        hx1 = hnx1(tmp_index)';
+        hny1 = hny';
+        hy1 = hny1(tmp_index)';
+
+        % find third 
+        index1 = mod(index-1+1+6,6)+1;
+        index2 = mod(index-1-1+6,6)+1;
+
+        tmp_index1 = index1' + 6*[0:length(index1)-1];
+        hnx2 = hnx';
+        tmp1_hx2 = hnx2(tmp_index1)';
+        hny2 = hny';
+        tmp1_hy2 = hny2(tmp_index1)';
+
+        tmp_index2 = index2' + 6*[0:length(index2)-1];
+        hnx2 = hnx';
+        tmp2_hx2 = hnx2(tmp_index2)';
+        hny2 = hny';
+        tmp2_hy2 = hny2(tmp_index2)';
+
+        mask = (tmp1_hx2-hx0).^2 + (tmp1_hy2-hy0).^2 >  (tmp2_hx2-hx0).^2 + (tmp2_hy2-hy0).^2 ;
+
+        hx2 = zeros(size(mask));
+        hx2(mask) =  tmp2_hx2(mask);
+        hx2(~mask) =  tmp1_hx2(~mask);
+
+        hy2 = zeros(size(mask));
+        hy2(mask) =  tmp2_hy2(mask);
+        hy2(~mask) =  tmp1_hy2(~mask);    
+
+        clear index index1 index2 hnx hny dis maxk tmp_index1 tmp_index2 tmp_index tmp1_hx2 tmp1_hy2 tmp2_hx2 tmp2_hy2
+
+        mask1 = zeros(size(hx1));
+        i1 = hx1<=0 | hx1>size(img,2) | hy1<=0 | hy1>size(img,1);
+        mask1(i1) = mask1(i1) + 1;
+        hx1(i1) = hx2(i1);
+        hy1(i1) = hy2(i1);
+
+        i2 = hx2<=0 | hx2>size(img,2) | hy2<=0 | hy2>size(img,1);
+        mask1(i2) = mask1(i2) + 1;
+
+        index = sub2ind(size(result),indexY,indexX);
+
+        index1 = mask1 == 0;
+        index2 = mask1 == 1;
+        index3 = mask1 == 2;   
+
+        lam1 = zeros(size(mask));
+        lam2 = zeros(size(mask));
+        lam3 = zeros(size(mask));
+        lam1(index1) = ( (hy1(index1)-hy2(index1)).*(hx0(index1)-hx2(index1)) + (hx2(index1)-hx1(index1)).*(hy0(index1)-hy2(index1)) ) ./ ( (hy1(index1)-hy2(index1)).*(hx_nearest(index1)-hx2(index1)) + (hx2(index1)-hx1(index1)).*(hy_nearest(index1)-hy2(index1)) );
+        lam2(index1) = ( (hy2(index1)-hy_nearest(index1)).*(hx0(index1)-hx2(index1)) + (hx_nearest(index1)-hx2(index1)).*(hy0(index1)-hy2(index1)) ) ./ ( (hy1(index1)-hy2(index1)).*(hx_nearest(index1)-hx2(index1)) + (hx2(index1)-hx1(index1)).*(hy_nearest(index1)-hy2(index1)) );
+        lam3(index1) = 1 - lam1(index1) - lam2(index1);
+
+        index = sub2ind(size(result),indexY(index1),indexX(index1));
+        p1 = sub2ind(size(img),hy_nearest(index1),hx_nearest(index1));
+        p2 = sub2ind(size(img),hy1(index1),hx1(index1));
+        p3 = sub2ind(size(img),hy2(index1),hx2(index1));
+
+        if(nargout>1)
+            InterpData.mask1 = mask1;
+            InterpData.p1 = p1;
+            InterpData.p2 = p2;
+            InterpData.p3 = p3;
+            InterpData.lam1 = lam1;
+            InterpData.lam2 = lam2;
+            InterpData.lam3 = lam3;
+            InterpData.index = index;
+            InterpData.hx1 = hx1;
+            InterpData.hy1 = hy1;
+            InterpData.hx_nearest = hx_nearest;
+            InterpData.hy_nearest = hy_nearest;
+        end
+    else
+        index1 = InterpData.mask1 == 0;
+        index2 = InterpData.mask1 == 1;
+        index3 = InterpData.mask1 == 2;
+        
+        p1         = InterpData.p1;
+        p2         = InterpData.p2;
+        p3         = InterpData.p3;
+        lam1       = InterpData.lam1;
+        lam2       = InterpData.lam2;
+        lam3       = InterpData.lam3;
+        index      = InterpData.index;
+        hx1        = InterpData.hx1;
+        hy1        = InterpData.hy1;
+        hx_nearest = InterpData.hx_nearest;
+        hy_nearest = InterpData.hy_nearest;
+    end
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    
+    result(index) = lam1(index1).*img(p1) + lam2(index1).*img(p2) + lam3(index1).*img(p3);
+    
+    index = sub2ind(size(result),indexY(index2),indexX(index2));
+    p1 = sub2ind(size(img),hy_nearest(index2),hx_nearest(index2));
+    p2 = sub2ind(size(img),hy1(index2),hx1(index2));
+    
+    result(index) = 0.5.*img(p1) + 0.5.*img(p2);
+    
+    index = sub2ind(size(result),indexY(index3),indexX(index3));
+    p1 = sub2ind(size(img),hy_nearest(index3),hx_nearest(index3));
+    
+    result(index) = img(p1);
+    
+end


### PR DESCRIPTION
-'barycentric' uses and adapts code from the KAIST decoding toolbox (Cho et al. "Modeling the calibration pipeline of the Lytro camera for high quality light-field image reconstruction",ICCV2013).
It is slow but generates larger images.
-'none' is a "non-destructive" mode from the paper (Le Pendu and Smolic,"High Resolution Light Field Recovery with Fourier Disparity Layer Completion, Demosaicing, and Super-Resolution",ICCP2020).
It extract a list of views within the disk aperture (unreliable corner views are not extracted) and without lossy interpolations.
It desactivates the colourMatrix transform to avoid mixing known data on the original RAW image with demosaiced data.
It also extracts a weight map per RGB component per view (zero weight indicate missing pixels that were not paired with an original pixel in the RAW image), and the following metadata:
  -DecodeOptions.Sampling.ST: S, T angular coordinates of each view.
  -DecodeOptions.Sampling.HexShiftStart: same as LensletGridModel.FirstPosShiftRow, required to perform hexagonal to square resampling later.
  -DecodeOptions.Sampling.SubPixAccuracy: space between 2 consecutive extracted views (measured in pixels on the RAW image).
This mode can be parameterized with 2 decoding options :
  -LensletBorderSkip: number of pixels to skip at the border of each lenslet (default=1.5 for Illum and F01).
  -NumViewsDiameter : number of extracted views on the diameter of the disk of views (default=25 for Illum, 17 for F01).

The new modes can be tested by setting DecodeOptions.ResampMethod='barycentric' or DecodeOptions.ResampMethod='none'.
Both 'barycentric' and 'none' are incompatible with the decoding mode WeightedInterp (automatically desactivated in this case).
The mode 'none' is also incompatible with eslf output (it generates 3-channel masks).