### PR TITLE
Added hot pixel correction with new option HotPixelCorrect (false by …

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Decoding improvements:
 - Improved colours and exposure with decode options NormaliseWIColours, NormaliseWIExposure and corrected use of metadata for Lytro Illum (behaviour of previous versions is still available with decode option ColourCompatibility).
 - New decode options CorrectSaturated and ClipMode for the recovery of saturated colours in the highlights.
 - New decode option EarlyWhiteBalance to perform white balance on the RAW lenslet image directly (reduce some colour artifacts).
+- New decode option HotPixelCorrect for hot pixel correction of the RAW image.
 - New ResampMethod option 'barycentric' from the ICCV2013 paper of Cho et al, "Modeling the calibration pipeline of the Lytro camera for high quality light-field image reconstruction".
 - New ResampMethod option 'none' from ICCP2020 paper of Le Pendu and Smolic, "High Resolution Light Field Recovery with Fourier Disparity Layer Completion, Demosaicing, and Super-Resolution".
 

--- a/LFReadHotPixels.m
+++ b/LFReadHotPixels.m
@@ -1,0 +1,21 @@
+% LFReadHotPixels - Read HotPixel binary file storing the indices of the hotpixels in the lenslet image.
+%
+% Usage: 
+%     HotPixelsXY = LFReadHotPixels( HotPixelsFname )
+%
+% Input :
+%     HotPixelsFname : Name of the hotpixel binary file.
+%
+% Outputs : 
+% 
+%     HotPixelsXY : Array containing the horizontal and vertical indices of
+%     the hotpixels. HotPixelsXY(:,1) contains horizontal indices and
+%     HotPixelsXY(:,2) contains the vertical indices.
+%
+
+function [HotPixelsXY] = LFReadHotPixels(HotPixelsFname)
+    fid=fopen(HotPixelsFname,'r','l');
+    numHotPixels = fread(fid,1,'uint32');
+    HotPixelsXY = 1+fread(fid,[numHotPixels,2],'uint16');
+    fclose(fid);
+end

--- a/LFUtilDecodeLytroFolder.m
+++ b/LFUtilDecodeLytroFolder.m
@@ -111,6 +111,7 @@
 %                         .ClipMode : Clipping for highlights : 'hard', 'soft' or 'none'. The default is 'soft' if CorrectSaturated is true, and 'hard' otherwise.
 %                                     ClipMode='none' prevents clipping of highlights. To retain values above the saturation level in the output integer format,
 %                                     the light field data is divided by its maximum value before conversion to integers, and the maximum value is saved in metadata as MaxLum.
+%                  .HotPixelCorrect : Performs hot pixel correction using a list of hot pixels detected on the sensor (default=false).
 %
 %     RectOptions : struct controlling the optional rectification process
 %         .CalibrationDatabasePath  : Path to the calibration file database, as created by

--- a/SupportFunctions/LFDecodeLensletImageDirect.m
+++ b/SupportFunctions/LFDecodeLensletImageDirect.m
@@ -45,6 +45,8 @@
 %          [Optional] EarlyWhiteBalance : Perform white balance directly on the RAW data, before demosaicing (default = false).
 %          [Optional] CorrectSaturated : Process saturated pixels on the sensor so that they appear white after white balance (default = false).
 %          [Optional] ClipMode : 'hard', 'soft', 'none'. The default is 'soft' if CorrectSaturated is true, 'hard' otherwise.
+%          [Optional] HotPixelCorrect : Performs hot pixel correction using a list of hot pixels detected on the sensor (default=false).
+%                                       If the option is active, the vertical and horizontal indices of the hot pixels must be defined temporarily in DecodeOptions.HotPixelsX and DecodeOptions.HotPixelsY (these fields are removed after the hot pixel correction is done).
 %
 % Output LF is a 5D array of size [Nj,Ni,Nl,Nk,3]. See [1] and the documentation accompanying this
 % toolbox for a brief description of the light field structure.
@@ -199,6 +201,12 @@ switch DecodeOptions.ClipMode
     case 'none'
     otherwise
         error(['Unknown ClipMode ''' DecodeOptions.ClipMode '''. Valid values are ''none'', ''soft'', ''hard''.']);
+end
+
+% Hot pixel correction
+if(DecodeOptions.HotPixelCorrect)
+    LensletImage = LFHotPixelCorrection(LensletImage,DecodeOptions.HotPixelsX,DecodeOptions.HotPixelsY);
+    DecodeOptions = rmfield(DecodeOptions,{'HotPixelsX','HotPixelsY'});
 end
 
 if(DecodeOptions.WeightedDemosaic || DecodeOptions.WeightedInterp)

--- a/SupportFunctions/LFFindWhiteImageByIndex.m
+++ b/SupportFunctions/LFFindWhiteImageByIndex.m
@@ -1,0 +1,38 @@
+% LFFindWhiteImageByIndex - Finds White images names with same structure
+% as the given file name (including full path and extension) but with
+% different indices.
+%
+% Usage: 
+%     [ImagesDir, WhiteImageNames] = LFFindWhiteImageByIndex(WhiteImageFname,WhiteImageIndices);
+% 
+% Inputs :
+% 
+%    WhiteImageFname : Full name of a raw white image.
+%
+%    WhiteImageIndices : vector containing the indices of the white images
+%    to find in the White raw Image Folder.
+% 
+% Outputs : 
+% 
+%     ImagesDir : White (and Black) image folder.
+%     
+%     WhiteImageNames : cell containing the filenames of all the white
+%     images found in the folder corresponding to the indices given in
+%     WhiteImageIndices.
+
+function [ImagesDir, WhiteImageNames] = LFFindWhiteImageByIndex(WhiteImageFname, WhiteImageIndices)
+
+[ImagesDir, WhiteImageName, ImageExt] = fileparts(WhiteImageFname);
+
+%Search for format of the white image file name
+[DigitsStart, DigitsEnd] = regexp(WhiteImageName,'_\d+','start','end');
+DigitsStart = DigitsStart(end);
+DigitsEnd = DigitsEnd(end);
+
+%Retrieve white images corresponding to the same format and with the target indices
+fdir = dir(ImagesDir);
+NumExpr = sprintf('%i|',floor(WhiteImageIndices));
+NumExpr = ['(' NumExpr(1:end-1) ')'];
+
+WhiteImageNames=regexp({fdir.name},['^' WhiteImageName(1:DigitsStart) '0*' NumExpr WhiteImageName(DigitsEnd+1:end) ImageExt '$'],'match');
+WhiteImageNames=[WhiteImageNames{:}];

--- a/SupportFunctions/LFHotPixelCorrection.m
+++ b/SupportFunctions/LFHotPixelCorrection.m
@@ -1,0 +1,38 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% original code from KAIST toolbox written by Donghyeon Cho.
+%
+% modified by Mikael Le Pendu
+%  - adapted inputs/outputs for the LFtoolbox pipeline.
+%
+% Name   : hotPixelCorrection  
+% Input  : img           - input image
+%          HotPixelsX    - list of column indices of hot pixels.
+%          HotPixelsY    - list of row indices of hot pixels.
+%
+% Output : result        - corrected image
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function result = LFHotPixelCorrection(img, HotPixelsX, HotPixelsY)
+    
+    RawSize = size(img);
+    
+    processed = HotPixelsX>1 & HotPixelsY>1 & HotPixelsX<RawSize(2) & HotPixelsY<RawSize(1);
+    HotPixelsX = HotPixelsX(processed);
+    HotPixelsY = HotPixelsY(processed);
+    
+    index = sub2ind(RawSize, HotPixelsY, HotPixelsX);
+    img(index) = 0;
+    
+    sum = 0;
+    for col=-1:1:1
+        for row=-1:1:1
+            w = exp(-sqrt(col^2+row^2));
+            sum = sum + w;
+            ind = sub2ind(RawSize,HotPixelsY+row,HotPixelsX+col);
+            img(index) = img(index) + img(ind).*w;
+        end
+    end
+    
+    img(index) = img(index)./sum;
+    result = img;
+    
+end


### PR DESCRIPTION
…default)

For Lytro Illum, the hot pixel's positions are read directly from the HOTPIXEL.BIN file.
For Lytro F01, the hot pixel's positions are detected from the 2 black images provided in calibration files.
Currently, hot pixels detection is in LFDecodeLytroImage. But it should probably be moved to calibration, and save a .json or .bin file, to avoid recomputing each time, and to make things consistent between cameras.

To avoid changing inputs of the function LFDecodeLensletImageDirect, I added the hot pixels indices in DecodeOptions and removed them after the correction is done.